### PR TITLE
Upgrade swagger codegen to version 2.4.27

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ COPY . ${APP_DIR}
 
 RUN mvn clean package
 
-FROM swaggerapi/swagger-codegen-cli:2.4.5
+FROM swaggerapi/swagger-codegen-cli:2.4.27
 
 # Setup environment
 ENV APP_DIR /usr/src/app

--- a/pom.xml
+++ b/pom.xml
@@ -120,6 +120,6 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <swagger-codegen-version>2.4.27</swagger-codegen-version>
         <maven-plugin-version>1.0.0</maven-plugin-version>
-        <junit-version>4.8.1</junit-version>
+        <junit-version>4.13.1</junit-version>
     </properties>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -122,4 +122,14 @@
         <maven-plugin-version>1.0.0</maven-plugin-version>
         <junit-version>4.13.1</junit-version>
     </properties>
+    <repositories>
+      <repository>
+        <snapshots>
+          <enabled>false</enabled>
+        </snapshots>
+        <id>central</id>
+        <name>Central Repository</name>
+        <url>https://repo.maven.apache.org/maven2</url>
+      </repository>
+    </repositories>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@
     </dependencies>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <swagger-codegen-version>2.4.19</swagger-codegen-version>
+        <swagger-codegen-version>2.4.27</swagger-codegen-version>
         <maven-plugin-version>1.0.0</maven-plugin-version>
         <junit-version>4.8.1</junit-version>
     </properties>

--- a/src/main/java/uk/co/wimit/codegen/languages/RubyClientGenerator.java
+++ b/src/main/java/uk/co/wimit/codegen/languages/RubyClientGenerator.java
@@ -582,7 +582,7 @@ public class RubyClientGenerator extends DefaultCodegen implements CodegenConfig
             varName = varName.replaceAll("-", "MINUS_");
             varName = varName.replaceAll("\\+", "PLUS_");
             varName = varName.replaceAll("\\.", "_DOT_");
-            return varName;
+            return "N" + varName;
         }
 
         // string

--- a/src/main/resources/ruby-client/base_object.mustache
+++ b/src/main/resources/ruby-client/base_object.mustache
@@ -6,7 +6,7 @@
 
           self.class.swagger_types.each_pair do |key, type|
             if type =~ /\AArray<(.*)>/i
-              # check to ensure the input is an array given that the the attribute
+              # check to ensure the input is an array given that the attribute
               # is documented as an array but the input is not
               if attributes[self.class.attribute_map[key]].is_a?(Array)
                 self.send("#{key}=", attributes[self.class.attribute_map[key]].map { |v| _deserialize($1, v) })

--- a/src/main/resources/ruby-client/client.mustache
+++ b/src/main/resources/ruby-client/client.mustache
@@ -107,6 +107,8 @@ module {{moduleName}}
           :verbose => @config.debugging
         }
 
+        req_opts.merge!(multipart: true) if header_params['Content-Type'].start_with? 'multipart/'
+
         # set custom cert, if provided
         req_opts[:cainfo] = @config.ssl_ca_cert if @config.ssl_ca_cert
 

--- a/src/main/resources/ruby-client/client.mustache
+++ b/src/main/resources/ruby-client/client.mustache
@@ -7,7 +7,7 @@ require 'json'
 require 'logger'
 require 'tempfile'
 require 'typhoeus'
-require 'uri'
+require 'addressable/uri'
 
 module {{moduleName}}
   module API
@@ -56,7 +56,7 @@ module {{moduleName}}
                               :message => response.return_message)
           else
             fail API::Error.new(:code => response.code,
-                              :response_headers => response.headers,
+                              :response_headers => response.headers.to_h,
                               :response_body => response.body),
                  response.status_message
           end
@@ -264,7 +264,7 @@ module {{moduleName}}
       def build_request_url(path)
         # Add leading and trailing slashes to path
         path = "/#{path}".gsub(/\/+/, '/')
-        URI.encode(@config.base_url + path)
+        Addressable::URI.encode(@config.base_url + path)
       end
 
       # Builds the HTTP request body

--- a/src/main/resources/ruby-client/client_spec.mustache
+++ b/src/main/resources/ruby-client/client_spec.mustache
@@ -81,6 +81,23 @@ RSpec.describe {{moduleName}}::API::Client do
     end
   end
 
+  describe '#build_request' do
+    let(:config) { {{moduleName}}::API::Configuration.new }
+    let(:client) { {{moduleName}}::API::Client.new(config) }
+
+    it 'does not send multipart to request' do
+      expect(Typhoeus::Request).to receive(:new).with(anything, hash_not_including(:multipart))
+      client.build_request(:get, '/test')
+    end
+
+    context 'when the content type is multipart' do
+      it 'sends multipart to request' do
+        expect(Typhoeus::Request).to receive(:new).with(anything, hash_including(multipart: true))
+        client.build_request(:get, '/test', header_params: { 'Content-Type' => 'multipart/form-data' })
+      end
+    end
+  end
+
   describe '#deserialize' do
     it "handles Array<Integer>" do
       client = {{moduleName}}::API::Client.new

--- a/src/main/resources/ruby-client/configuration.mustache
+++ b/src/main/resources/ruby-client/configuration.mustache
@@ -2,7 +2,7 @@
 {{> api_info}}
 =end
 
-require 'uri'
+require 'addressable/uri'
 
 module {{moduleName}}
   module API
@@ -168,7 +168,7 @@ module {{moduleName}}
 
       def base_url
         url = "#{scheme}://#{[host, base_path].join('/').gsub(/\/+/, '/')}".sub(/\/+\z/, '')
-        URI.encode(url)
+        Addressable::URI.encode(url)
       end
 
       # Gets API key (with prefix if set).

--- a/src/main/resources/ruby-client/gemspec.mustache
+++ b/src/main/resources/ruby-client/gemspec.mustache
@@ -31,4 +31,5 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'typhoeus', '~> 1.0', '>= 1.0.1'
   s.add_runtime_dependency 'json', '~> 2.1', '>= 2.1.0'
+  s.add_runtime_dependency 'addressable', '~> 2.3', '>= 2.3.0'
 end


### PR DESCRIPTION
## Description

Upgrade `swagger-codegen` to version `2.4.27`.

The main reason is to remove the deprecated usages of `URI.encode` (deprecated in Ruby 2.7, removed in Ruby 3.0) and make the client compatible with Ruby 3.0+.

Includes porting:

* swagger-api/swagger-codegen#11114
* swagger-api/swagger-codegen#9908
* swagger-api/swagger-codegen#9019
* swagger-api/swagger-codegen#10445


Additionally the maven central repository protocol is changed to `HTTPS`.

## Related links

* https://bugs.ruby-lang.org/issues/17309
* https://docs.knapsackpro.com/2020/uri-escape-is-obsolete-percent-encoding-your-query-string